### PR TITLE
Remove hostname label from labels

### DIFF
--- a/ovnmonitor/exporter.go
+++ b/ovnmonitor/exporter.go
@@ -64,7 +64,6 @@ func (e *Exporter) initParas(cfg *Configuration) {
 	e.pollInterval = cfg.PollInterval
 
 	e.Client.Timeout = cfg.PollTimeout
-	e.Client.System.Hostname = os.Getenv("KUBE_NODE_NAME")
 
 	e.Client.Database.Northbound.Name = "OVN_Northbound"
 	e.Client.Database.Northbound.Socket.Remote = cfg.DatabaseNorthboundSocketRemote
@@ -159,13 +158,13 @@ func (e *Exporter) exportOvnStatusGauge() {
 	metricOvnHealthyStatus.Reset()
 	result := e.getOvnStatus()
 	for k, v := range result {
-		metricOvnHealthyStatus.WithLabelValues(e.Client.System.Hostname, k).Set(float64(v))
+		metricOvnHealthyStatus.WithLabelValues(k).Set(float64(v))
 	}
 
 	metricOvnHealthyStatusContent.Reset()
 	statusResult := e.getOvnStatusContent()
 	for k, v := range statusResult {
-		metricOvnHealthyStatusContent.WithLabelValues(e.Client.System.Hostname, k, v).Set(float64(1))
+		metricOvnHealthyStatusContent.WithLabelValues(k, v).Set(float64(1))
 	}
 }
 
@@ -183,12 +182,12 @@ func (e *Exporter) exportOvnDBFileSizeGauge() {
 			slog.Error(fmt.Sprintf("Failed to get the DB size for database %s", database), "error", err)
 			return
 		}
-		metricDBFileSize.WithLabelValues(e.Client.System.Hostname, database).Set(float64(fileInfo.Size()))
+		metricDBFileSize.WithLabelValues(database).Set(float64(fileInfo.Size()))
 	}
 }
 
 func (e *Exporter) exportOvnRequestErrorGauge() {
-	metricRequestErrorNums.WithLabelValues(e.Client.System.Hostname).Set(float64(e.errors))
+	metricRequestErrorNums.WithLabelValues().Set(float64(e.errors))
 }
 
 func (e *Exporter) exportOvnChassisGauge() {
@@ -220,9 +219,9 @@ func (e *Exporter) exportOvnClusterEnableGauge() {
 		slog.Error("failed to get output of cluster status", "error", err)
 	}
 	if isClusterEnabled {
-		metricClusterEnabled.WithLabelValues(e.Client.System.Hostname, e.Client.Database.Northbound.File.Data.Path).Set(1)
+		metricClusterEnabled.WithLabelValues(e.Client.Database.Northbound.File.Data.Path).Set(1)
 	} else {
-		metricClusterEnabled.WithLabelValues(e.Client.System.Hostname, e.Client.Database.Northbound.File.Data.Path).Set(0)
+		metricClusterEnabled.WithLabelValues(e.Client.Database.Northbound.File.Data.Path).Set(0)
 	}
 }
 
@@ -252,9 +251,9 @@ func (e *Exporter) exportOvnDBStatusGauge() {
 			return
 		}
 		if ok {
-			metricDBStatus.WithLabelValues(e.Client.System.Hostname, database).Set(1)
+			metricDBStatus.WithLabelValues(database).Set(1)
 		} else {
-			metricDBStatus.WithLabelValues(e.Client.System.Hostname, database).Set(0)
+			metricDBStatus.WithLabelValues(database).Set(0)
 
 			switch database {
 			case "OVN_Northbound":

--- a/ovnmonitor/metric.go
+++ b/ovnmonitor/metric.go
@@ -11,7 +11,6 @@ var (
 			Help:      "OVN Health Status. The values are:(2) for standby or follower, (1) for active or leader, (0) for unhealthy.",
 		},
 		[]string{
-			"hostname",
 			"component",
 		})
 
@@ -22,7 +21,6 @@ var (
 			Help:      "OVN Health Status. The values are always 1. While the value of status label is the really status report.",
 		},
 		[]string{
-			"hostname",
 			"component",
 			"status",
 		})
@@ -34,7 +32,6 @@ var (
 			Help:      "The number of failed requests to OVN stack.",
 		},
 		[]string{
-			"hostname",
 		})
 
 	metricDBFileSize = prometheus.NewGaugeVec(
@@ -44,7 +41,6 @@ var (
 			Help:      "The size of a database file associated with an OVN component. The unit is Bytes.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 		})
 
@@ -69,7 +65,6 @@ var (
 			Help:      "The information about OVN logical switch. This metric is always up (1).",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"name",
 		})
@@ -81,7 +76,6 @@ var (
 			Help:      "Provides the external IDs and values associated with OVN logical switches. This metric is always up (1).",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"key",
 			"value",
@@ -95,7 +89,6 @@ var (
 			Help:      "Provides the association between a logical switch and a logical switch port. This metric is always up (1).",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"port",
 			"logical_switch_name",
@@ -108,7 +101,6 @@ var (
 			Help:      "The value of the tunnel key associated with the logical switch.",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"logical_switch_name",
 		})
@@ -120,7 +112,6 @@ var (
 			Help:      "The number of logical switch ports connected to the OVN logical switch.",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"logical_switch_name",
 		})
@@ -132,7 +123,6 @@ var (
 			Help:      "The information about OVN logical switch port. This metric is always up (1).",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"name",
 			"chassis",
@@ -150,7 +140,6 @@ var (
 			Help:      "The value of the tunnel key associated with the logical switch port.",
 		},
 		[]string{
-			"hostname",
 			"uuid",
 			"logical_switch_name",
 			"port_name",
@@ -164,7 +153,6 @@ var (
 			Help:      "Is OVN clustering enabled (1) or not (0).",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 		})
 
@@ -175,7 +163,6 @@ var (
 			Help:      "A metric with a constant '1' value labeled by server role.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -189,7 +176,6 @@ var (
 			Help:      "A metric with a constant '1' value labeled by server status.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -203,7 +189,6 @@ var (
 			Help:      "The current raft term known by this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -216,7 +201,6 @@ var (
 			Help:      "Is this server consider itself a leader (1) or not (0).",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -229,7 +213,6 @@ var (
 			Help:      "Is this server voted itself as a leader (1) or not (0).",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -242,7 +225,6 @@ var (
 			Help:      "The current election timer value.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -255,7 +237,6 @@ var (
 			Help:      "The number of log entries not yet committed by this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -268,7 +249,6 @@ var (
 			Help:      "The number of log entries not yet applied by this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -281,7 +261,6 @@ var (
 			Help:      "The log entry index start value associated with this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -294,7 +273,6 @@ var (
 			Help:      "The log entry index next value associated with this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -307,7 +285,6 @@ var (
 			Help:      "The total number of inbound connections to the server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -320,7 +297,6 @@ var (
 			Help:      "The total number of outbound connections from the server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -333,7 +309,6 @@ var (
 			Help:      "The total number of failed inbound connections to the server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -346,7 +321,6 @@ var (
 			Help:      "The total number of failed outbound connections from the server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -360,7 +334,6 @@ var (
 			Help:      "This metric appears when a cluster peer is connected to this server. This metric is always 1.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -375,7 +348,6 @@ var (
 			Help:      "This metric appears when this server connects to a cluster peer. This metric is always 1.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -390,7 +362,6 @@ var (
 			Help:      "The total number of peers in this server's cluster.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -403,7 +374,6 @@ var (
 			Help:      "The raft's next index associated with this cluster peer.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -417,7 +387,6 @@ var (
 			Help:      "The raft's match index associated with this cluster peer.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -431,7 +400,6 @@ var (
 			Help:      "The raft's next index associated with this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -444,7 +412,6 @@ var (
 			Help:      "The raft's match index associated with this server.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 			"server_id",
 			"cluster_id",
@@ -457,7 +424,6 @@ var (
 			Help:      "The status of OVN NB/SB DB, (1) for healthy, (0) for unhealthy.",
 		},
 		[]string{
-			"hostname",
 			"db_name",
 		})
 )

--- a/ovnmonitor/util.go
+++ b/ovnmonitor/util.go
@@ -118,19 +118,19 @@ func (e *Exporter) setLogicalSwitchInfoMetric() {
 		e.IncrementErrorCounter()
 	} else {
 		for _, lsw := range lsws {
-			metricLogicalSwitchInfo.WithLabelValues(e.Client.System.Hostname, lsw.UUID, lsw.Name).Set(1)
-			metricLogicalSwitchPortsNum.WithLabelValues(e.Client.System.Hostname, lsw.UUID, lsw.Name).Set(float64(len(lsw.Ports)))
+			metricLogicalSwitchInfo.WithLabelValues(lsw.UUID, lsw.Name).Set(1)
+			metricLogicalSwitchPortsNum.WithLabelValues(lsw.UUID, lsw.Name).Set(float64(len(lsw.Ports)))
 			if len(lsw.Ports) > 0 {
 				for _, p := range lsw.Ports {
-					metricLogicalSwitchPortBinding.WithLabelValues(e.Client.System.Hostname, lsw.UUID, p, lsw.Name).Set(1)
+					metricLogicalSwitchPortBinding.WithLabelValues(lsw.UUID, p, lsw.Name).Set(1)
 				}
 			}
 			if len(lsw.ExternalIDs) > 0 {
 				for k, v := range lsw.ExternalIDs {
-					metricLogicalSwitchExternalIDs.WithLabelValues(e.Client.System.Hostname, lsw.UUID, k, v, lsw.Name).Set(1)
+					metricLogicalSwitchExternalIDs.WithLabelValues(lsw.UUID, k, v, lsw.Name).Set(1)
 				}
 			}
-			metricLogicalSwitchTunnelKey.WithLabelValues(e.Client.System.Hostname, lsw.UUID, lsw.Name).Set(float64(lsw.TunnelKey))
+			metricLogicalSwitchTunnelKey.WithLabelValues(lsw.UUID, lsw.Name).Set(float64(lsw.TunnelKey))
 		}
 	}
 }
@@ -168,9 +168,9 @@ func (e *Exporter) setLogicalSwitchPortInfoMetric() {
 	} else {
 		for _, port := range lswps {
 			mac, ip := lspAddress(port.Addresses)
-			metricLogicalSwitchPortInfo.WithLabelValues(e.Client.System.Hostname, port.UUID, port.Name, port.ChassisUUID,
+			metricLogicalSwitchPortInfo.WithLabelValues(port.UUID, port.Name, port.ChassisUUID,
 				port.LogicalSwitchName, port.DatapathUUID, port.PortBindingUUID, mac, ip).Set(1)
-			metricLogicalSwitchPortTunnelKey.WithLabelValues(e.Client.System.Hostname, port.UUID, port.LogicalSwitchName, port.Name).Set(float64(port.TunnelKey))
+			metricLogicalSwitchPortTunnelKey.WithLabelValues(port.UUID, port.LogicalSwitchName, port.Name).Set(float64(port.TunnelKey))
 		}
 	}
 }
@@ -259,31 +259,31 @@ func getClusterInfo(direction, dbName string) (*OVNDBClusterStatus, error) {
 }
 
 func (e *Exporter) setOvnClusterInfoMetric(c *OVNDBClusterStatus, dbName string) {
-	metricClusterRole.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid, c.role).Set(1)
-	metricClusterStatus.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid, c.status).Set(1)
-	metricClusterTerm.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.term)
+	metricClusterRole.WithLabelValues(dbName, c.sid, c.cid, c.role).Set(1)
+	metricClusterStatus.WithLabelValues(dbName, c.sid, c.cid, c.status).Set(1)
+	metricClusterTerm.WithLabelValues(dbName, c.sid, c.cid).Set(c.term)
 
 	if c.leader == "self" {
-		metricClusterLeaderSelf.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(1)
+		metricClusterLeaderSelf.WithLabelValues(dbName, c.sid, c.cid).Set(1)
 	} else {
-		metricClusterLeaderSelf.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(0)
+		metricClusterLeaderSelf.WithLabelValues(dbName, c.sid, c.cid).Set(0)
 	}
 	if c.vote == "self" {
-		metricClusterVoteSelf.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(1)
+		metricClusterVoteSelf.WithLabelValues(dbName, c.sid, c.cid).Set(1)
 	} else {
-		metricClusterVoteSelf.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(0)
+		metricClusterVoteSelf.WithLabelValues(dbName, c.sid, c.cid).Set(0)
 	}
 
-	metricClusterElectionTimer.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.electionTimer)
-	metricClusterNotCommittedEntryCount.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.logNotCommitted)
-	metricClusterNotAppliedEntryCount.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.logNotApplied)
-	metricClusterLogIndexStart.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.logIndexStart)
-	metricClusterLogIndexNext.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.logIndexNext)
+	metricClusterElectionTimer.WithLabelValues(dbName, c.sid, c.cid).Set(c.electionTimer)
+	metricClusterNotCommittedEntryCount.WithLabelValues(dbName, c.sid, c.cid).Set(c.logNotCommitted)
+	metricClusterNotAppliedEntryCount.WithLabelValues(dbName, c.sid, c.cid).Set(c.logNotApplied)
+	metricClusterLogIndexStart.WithLabelValues(dbName, c.sid, c.cid).Set(c.logIndexStart)
+	metricClusterLogIndexNext.WithLabelValues(dbName, c.sid, c.cid).Set(c.logIndexNext)
 
-	metricClusterInConnTotal.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.connIn)
-	metricClusterOutConnTotal.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.connOut)
-	metricClusterInConnErrTotal.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.connInErr)
-	metricClusterOutConnErrTotal.WithLabelValues(e.Client.System.Hostname, dbName, c.sid, c.cid).Set(c.connOutErr)
+	metricClusterInConnTotal.WithLabelValues(dbName, c.sid, c.cid).Set(c.connIn)
+	metricClusterOutConnTotal.WithLabelValues(dbName, c.sid, c.cid).Set(c.connOut)
+	metricClusterInConnErrTotal.WithLabelValues(dbName, c.sid, c.cid).Set(c.connInErr)
+	metricClusterOutConnErrTotal.WithLabelValues(dbName, c.sid, c.cid).Set(c.connOutErr)
 }
 
 func parseDbStatus(output string) int {


### PR DESCRIPTION
In kube-ovn the hostname is set to be ENV KUBE_NODE_NAME. This does not make sense from a standalone exporter. Prometheus will set the instance label of the exporter which should be enough. Therefore hostname label is removed.