### PR TITLE
Remove more unused config options

### DIFF
--- a/ovnmonitor/config.go
+++ b/ovnmonitor/config.go
@@ -43,18 +43,10 @@ func ParseFlags() (*Configuration, error) {
 		argDatabaseNorthboundSocketRemote  = pflag.String("database.northbound.socket.remote", "unix:/run/ovn/ovnnb_db.sock", "JSON-RPC unix socket to OVN NB db.")
 		argDatabaseNorthboundSocketControl = pflag.String("database.northbound.socket.control", "/run/ovn/ovnnb_db.ctl", "control socket to OVN NB app.")
 		argDatabaseNorthboundFileDataPath  = pflag.String("database.northbound.file.data.path", "/etc/ovn/ovnnb_db.db", "OVN NB db file.")
-		argDatabaseNorthboundFilePidPath   = pflag.String("database.northbound.file.pid.path", "/run/ovn/ovnnb_db.pid", "OVN NB db process id file.")
-		argDatabaseNorthboundPortDefault   = pflag.Int("database.northbound.port.default", 6641, "OVN NB db network socket port.")
-		argDatabaseNorthboundPortSsl       = pflag.Int("database.northbound.port.ssl", 6631, "OVN NB db network socket secure port.")
-		argDatabaseNorthboundPortRaft      = pflag.Int("database.northbound.port.raft", 6643, "OVN NB db network port for clustering (raft)")
 
 		argDatabaseSouthboundSocketRemote  = pflag.String("database.southbound.socket.remote", "unix:/run/ovn/ovnsb_db.sock", "JSON-RPC unix socket to OVN SB db.")
 		argDatabaseSouthboundSocketControl = pflag.String("database.southbound.socket.control", "/run/ovn/ovnsb_db.ctl", "control socket to OVN SB app.")
 		argDatabaseSouthboundFileDataPath  = pflag.String("database.southbound.file.data.path", "/etc/ovn/ovnsb_db.db", "OVN SB db file.")
-		argDatabaseSouthboundFilePidPath   = pflag.String("database.southbound.file.pid.path", "/run/ovn/ovnsb_db.pid", "OVN SB db process id file.")
-		argDatabaseSouthboundPortDefault   = pflag.Int("database.southbound.port.default", 6642, "OVN SB db network socket port.")
-		argDatabaseSouthboundPortSsl       = pflag.Int("database.southbound.port.ssl", 6632, "OVN SB db network socket secure port.")
-		argDatabaseSouthboundPortRaft      = pflag.Int("database.southbound.port.raft", 6644, "OVN SB db network port for clustering (raft)")
 
 		argServiceNorthdFilePidPath   = pflag.String("service.ovn.northd.file.pid.path", "/var/run/ovn/ovn-northd.pid", "OVN northd daemon process id file.")
 		argServiceNorthdSocketControl = pflag.String("service.ovn.northd.socket.control", "", "OVN northd control socket to northd app.")
@@ -71,18 +63,10 @@ func ParseFlags() (*Configuration, error) {
 		DatabaseNorthboundSocketRemote:  *argDatabaseNorthboundSocketRemote,
 		DatabaseNorthboundSocketControl: *argDatabaseNorthboundSocketControl,
 		DatabaseNorthboundFileDataPath:  *argDatabaseNorthboundFileDataPath,
-		DatabaseNorthboundFilePidPath:   *argDatabaseNorthboundFilePidPath,
-		DatabaseNorthboundPortDefault:   *argDatabaseNorthboundPortDefault,
-		DatabaseNorthboundPortSsl:       *argDatabaseNorthboundPortSsl,
-		DatabaseNorthboundPortRaft:      *argDatabaseNorthboundPortRaft,
 
 		DatabaseSouthboundSocketRemote:  *argDatabaseSouthboundSocketRemote,
 		DatabaseSouthboundSocketControl: *argDatabaseSouthboundSocketControl,
 		DatabaseSouthboundFileDataPath:  *argDatabaseSouthboundFileDataPath,
-		DatabaseSouthboundFilePidPath:   *argDatabaseSouthboundFilePidPath,
-		DatabaseSouthboundPortDefault:   *argDatabaseSouthboundPortDefault,
-		DatabaseSouthboundPortSsl:       *argDatabaseSouthboundPortSsl,
-		DatabaseSouthboundPortRaft:      *argDatabaseSouthboundPortRaft,
 		ServiceNorthdFilePidPath:        *argServiceNorthdFilePidPath,
 		ServiceNorthdSocketControl:      *argServiceNorthdSocketControl,
 	}

--- a/ovnmonitor/exporter.go
+++ b/ovnmonitor/exporter.go
@@ -74,19 +74,11 @@ func (e *Exporter) initParas(cfg *Configuration) {
 	e.Client.Database.Northbound.Socket.Remote = cfg.DatabaseNorthboundSocketRemote
 	e.Client.Database.Northbound.Socket.Control = "unix:" + cfg.DatabaseNorthboundSocketControl
 	e.Client.Database.Northbound.File.Data.Path = cfg.DatabaseNorthboundFileDataPath
-	e.Client.Database.Northbound.File.Pid.Path = cfg.DatabaseNorthboundFilePidPath
-	e.Client.Database.Northbound.Port.Default = cfg.DatabaseNorthboundPortDefault
-	e.Client.Database.Northbound.Port.Ssl = cfg.DatabaseNorthboundPortSsl
-	e.Client.Database.Northbound.Port.Raft = cfg.DatabaseNorthboundPortRaft
 
 	e.Client.Database.Southbound.Name = "OVN_Southbound"
 	e.Client.Database.Southbound.Socket.Remote = cfg.DatabaseSouthboundSocketRemote
 	e.Client.Database.Southbound.Socket.Control = "unix:" + cfg.DatabaseSouthboundSocketControl
 	e.Client.Database.Southbound.File.Data.Path = cfg.DatabaseSouthboundFileDataPath
-	e.Client.Database.Southbound.File.Pid.Path = cfg.DatabaseSouthboundFilePidPath
-	e.Client.Database.Southbound.Port.Default = cfg.DatabaseSouthboundPortDefault
-	e.Client.Database.Southbound.Port.Ssl = cfg.DatabaseSouthboundPortSsl
-	e.Client.Database.Southbound.Port.Raft = cfg.DatabaseSouthboundPortRaft
 
 	e.Client.Service.Northd.File.Pid.Path = cfg.ServiceNorthdFilePidPath
 	if cfg.ServiceNorthdSocketControl != "" {


### PR DESCRIPTION
All those options are either not used by the kubeovn exporter code or not even used by the ovsdb lib.